### PR TITLE
feat: Add julius submodule for LLM service fingerprinting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 [submodule "modules/brutus"]
 	path = modules/brutus
 	url = https://github.com/praetorian-inc/brutus.git
+[submodule "modules/julius"]
+	path = modules/julius
+	url = https://github.com/praetorian-inc/julius.git

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ setup-internal: setup
 	git submodule update --init modules/brutus || echo "⚠️  brutus skipped (no access)"
 	git submodule update --init modules/capability-sdk || echo "⚠️  capability-sdk skipped (no access)"
 	git submodule update --init modules/diocletian || echo "⚠️  diocletian skipped (no access)"
+	git submodule update --init modules/julius || echo "⚠️  julius skipped (no access)"
 	git submodule update --init modules/nero || echo "⚠️  nero skipped (no access)"
 	git submodule update --init modules/noseyparkerplusplus || echo "⚠️  noseyparkerplusplus skipped (no access)"
 	git submodule update --init modules/nuclei-templates || echo "⚠️  nuclei-templates skipped (no access)"

--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ Diocletian provides cloud security assessment capabilities for identifying misco
 
 ---
 
+### Julius - LLM Service Fingerprinting
+
+**Identify LLM services running on target endpoints.**
+
+Julius is an LLM service fingerprinting tool that detects what AI/ML platform is running on a target by sending HTTP probes and matching responses. Supports 15+ services including Ollama, vLLM, llama.cpp, and enterprise platforms like NVIDIA NIM.
+
+**Key Features:**
+- 15+ LLM service fingerprints (self-hosted, RAG platforms, cloud)
+- YAML-based extensible probe definitions
+- Model extraction and Augustus generator integration
+- Multiple output formats (table, JSON, JSONL)
+
+[Documentation](./modules/julius)
+
+---
+
 ### NoseyParker++ - Enhanced Secret Scanner
 
 **Internal version of NoseyParker with additional ML features.**


### PR DESCRIPTION
## Summary
- Add julius as a new internal module for LLM service fingerprinting
- Update `.gitmodules` with julius repository reference
- Add julius to `Makefile` setup-internal target
- Add documentation section for Julius in README.md

## Test plan
- [ ] Verify `make setup-internal` initializes the julius submodule
- [ ] Confirm julius documentation renders correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)