### PR TITLE
feat: add pius asset enumeration submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "modules/aurelian"]
 	path = modules/aurelian
 	url = https://github.com/praetorian-inc/aurelian.git
+[submodule "modules/pius"]
+	path = modules/pius
+	url = https://github.com/praetorian-inc/pius.git

--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ Nero is a default credential scanner with a plugin architecture supporting multi
 
 ---
 
+### Pius - Asset Enumeration
+
+**Discover and enumerate assets across your attack surface.**
+
+Pius is an asset enumeration tool designed to identify and catalog assets within target environments, supporting attack surface management and reconnaissance workflows.
+
+**Key Features:**
+- Comprehensive asset discovery
+- Multiple enumeration techniques
+- Structured output for pipeline integration
+- Chariot platform integration
+
+[Documentation](./modules/pius)
+
+---
+
 ### Trajan - CI/CD Security Scanner
 
 **Detect security vulnerabilities in GitHub Actions workflows.**


### PR DESCRIPTION
## Summary
- Add Pius as a new submodule for asset enumeration
- Document Pius in the README under Internal Tools section
- Configure submodule in .gitmodules

## Test plan
- [ ] Verify submodule initializes correctly with `git submodule update --init modules/pius`
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)