### PR TITLE
feat: add constantine vulnerability discovery submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,6 @@
 [submodule "modules/vespasian"]
 	path = modules/vespasian
 	url = https://github.com/praetorian-inc/vespasian.git
+[submodule "modules/constantine"]
+	path = modules/constantine
+	url = https://github.com/praetorian-inc/constantine.git

--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ Aurelian provides cloud attack capabilities for identifying misconfigurations an
 
 ---
 
+### Constantine - Vulnerability Discovery & Exploitation Engine
+
+**Discover and exploit vulnerabilities across your attack surface.**
+
+Constantine is a vulnerability discovery and exploitation engine that orchestrates scanning, ingestion, and reporting workflows to identify and validate exploitable vulnerabilities at scale.
+
+**Key Features:**
+- Automated vulnerability discovery and exploitation
+- Modular scanner and reporter architecture
+- Orchestrated scanning workflows
+- Structured reporting for integration pipelines
+
+[Documentation](./modules/constantine)
+
+---
+
 ### Brutus - Credential Attack Framework
 
 **Fast, zero-dependency credential testing in Go.**


### PR DESCRIPTION
## Summary
- Add [constantine](https://github.com/praetorian-inc/constantine) as a submodule under `modules/constantine`
- Update README with Constantine entry under Attack Tools as a vulnerability discovery and exploitation engine

## Test plan
- [ ] Verify `git submodule update --init modules/constantine` clones successfully
- [ ] Verify README renders correctly with the new Constantine section

🤖 Generated with [Claude Code](https://claude.com/claude-code)